### PR TITLE
Choose the remote more wisely

### DIFF
--- a/git-url
+++ b/git-url
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # git-url prints a URL to a file
 # usage
@@ -15,8 +16,10 @@ if [ ! -f "$1" ]; then
 fi
 
 cd -- ${GIT_PREFIX:-.}
+branch=$(git rev-parse --abbrev-ref HEAD@{push} 2>/dev/null || echo "origin/master")
 
-remote=origin
+remote=${branch%%/*}
+branch=${branch#*/}
 if [ ! -z "$2" ]; then
     remote=$2
 fi
@@ -28,7 +31,7 @@ if [ "$(echo $remote_url | grep 'git@' | wc -l)" == "1" ]; then
     remote_url=$(echo $remote_url | sed 's|git@|https://|g')
 fi
 
-branch=$(git rev-parse --abbrev-ref HEAD)
+
 
 relative_file_path=$(git ls-files --full-name $1)
 


### PR DESCRIPTION
If a branch has a remote branch to track, we display its URL, which is
typically that of a fork. If there is no remote branch, we fall back
to "origin/master", which at least it is guaranteed to work.

As for the utility of this, if I'm working on a branch that I haven't
pushed yet, the old version gives an invalid URL. For instance, for my
currently not-pushed branch:

    $ LANG=C git rev-parse --abbrev-ref HEAD@{push}
    fatal: no upstream configured for branch 'iadaiada'
    # This URL does not exist!
    $ git-url README.md
    https://github.com/Piojo/qontract-reconcile/blob/iadaiada/README.md
    # But this one does
    $ bash $this_repo/git-url README.md
    https://github.com/Piojo/qontract-reconcile/blob/master/README.md
    # And now this works as expected
    $ bash ~/paso/git-url/git-url README.md upstream
    https://github.com/app-sre/qontract-reconcile/blob/master/README.md
