### PR TITLE
More robust git@ detection

### DIFF
--- a/git-url
+++ b/git-url
@@ -26,7 +26,7 @@ fi
 
 remote_url=$(git remote get-url $remote | sed 's/\.git//g')
 
-if [ "$(echo $remote_url | grep 'git@' | wc -l)" == "1" ]; then
+if [[ "$remote_url" == *"git@"* ]]; then
     remote_url=$(echo $remote_url | sed 's|:|/|g')
     remote_url=$(echo $remote_url | sed 's|git@|https://|g')
 fi


### PR DESCRIPTION
`wc` can have whitespace in its output so the direct comparison to `1` might fail.  A substring check is more robust.